### PR TITLE
use backticks for movie title in onclick to handle special characters 

### DIFF
--- a/templates/movie.html
+++ b/templates/movie.html
@@ -31,8 +31,8 @@
                     <span>⏱ {{ movie.runtime }} min</span>
                 </div>
                 <p class="overview">{{ movie.overview }}</p>
-                <button class="search-btn" onclick="addToWatchlist({'{ movie.id }}', '{{ movie.title }}', '{{ movie.poster_path }}')">
-                    + Add to Watchlist
+                <button class="search-btn" onclick="addToWatchlist({{ movie.id }}, `{{ movie.title }}`, '{{ movie.poster_path }}')">
+                 + Add to Watchlist
                 </button>
             </div>
         </div>


### PR DESCRIPTION
fix: use backticks for movie title in onclick to handle special characters 